### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/jmizero/9bccf9b8-3888-4cb9-9fab-1c5a9986ba91/de9639cf-e040-4621-b3b4-95a61781c868/_apis/work/boardbadge/a171ba0f-30cb-4e05-8dcc-1001247f75eb)](https://dev.azure.com/jmizero/9bccf9b8-3888-4cb9-9fab-1c5a9986ba91/_boards/board/t/de9639cf-e040-4621-b3b4-95a61781c868/Microsoft.RequirementCategory)
 # Week5-Assignment


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#56](https://dev.azure.com/jmizero/9bccf9b8-3888-4cb9-9fab-1c5a9986ba91/_workitems/edit/56). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.